### PR TITLE
Faraday 0.6 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "faraday"
+gem "faraday-stack"
 gem "yajl-ruby",          ">=0.7.7", :require => "yajl"
 gem "json_pure",          ">=1.4.6", :require => "json"
 
@@ -11,6 +11,7 @@ group :development do
   gem "rspec-expectations", ">=2.0.0.beta.20"
   gem "rr",                 ">=0.10.11"
   gem "rake",               ">=0.8.7"
-  gem "ruby-debug"
   gem "parka",              ">=0.4.3"
+  gem "ruby-debug",         :platforms => :ruby_18
+  gem "ruby-debug19",       :platforms => :ruby_19
 end

--- a/lib/indextank.rb
+++ b/lib/indextank.rb
@@ -1,4 +1,4 @@
-require 'faraday'
+require 'faraday_stack'
 require 'uri'
 
 directory = File.expand_path(File.dirname(__FILE__))
@@ -7,13 +7,11 @@ require File.join(directory, 'indextank', 'client')
 module IndexTank
   VERSION = "1.0.8.1"
 
-  def self.setup_connection(url, &block)
+  def self.setup_connection(url)
     @conn = Faraday::Connection.new(:url => url) do |builder|
+      builder.use FaradayStack::ResponseJSON
+      yield builder if block_given? 
       builder.adapter Faraday.default_adapter
-      builder.use Faraday::Response::Yajl
-      if block_given? 
-        block.call builder
-      end 
     end
     @uri = URI.parse(url)
     @conn.basic_auth @uri.user,@uri.password

--- a/lib/indextank/client.rb
+++ b/lib/indextank/client.rb
@@ -7,8 +7,9 @@ module IndexTank
 
     def initialize(api_url)
       @uri = api_url
-      builder = Proc.new { |builder| builder.use ClientResponseMiddleware }
-      @conn = IndexTank.setup_connection(api_url, &builder)
+      @conn = IndexTank.setup_connection(api_url) do |faraday|
+        faraday.use ClientResponseMiddleware
+      end
     end
 
     def indexes(name = nil)
@@ -36,18 +37,16 @@ module IndexTank
   end
 
   class ClientResponseMiddleware < Faraday::Response::Middleware
-    def self.register_on_complete(env)
-      env[:response].on_complete do |finished_env|
-        case finished_env[:status]
-        when 200
-          nil # this is the expected return code
-        when 204
-          nil # this is the expected return code for empty responses
-        when 401
-          raise InvalidApiKey
-        else
-          raise UnexpectedHTTPException, finished_env[:body]
-        end
+    def on_complete(env)
+      case env[:status]
+      when 200
+        nil # this is the expected return code
+      when 204
+        nil # this is the expected return code for empty responses
+      when 401
+        raise InvalidApiKey
+      else
+        raise UnexpectedHTTPException, finished_env[:body]
       end
     end
 

--- a/lib/indextank/function.rb
+++ b/lib/indextank/function.rb
@@ -8,9 +8,10 @@ module IndexTank
       @uri        = "#{function_url}/#{index}"
       @index      = index
       @definition = definition
-      # Function and Document have the same Response statuses .. so borrow DocumentResponseMiddleware
-      builder = Proc.new { |builder| builder.use IndexTank::DocumentResponseMiddleware }
-      @conn  = IndexTank.setup_connection(@uri, &builder)
+      @conn = IndexTank.setup_connection(@uri) do |faraday|
+        # Function and Document have the same Response statuses
+        faraday.use IndexTank::DocumentResponseMiddleware
+      end
     end
 
     def add(options = {})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,8 +21,8 @@ end
 def stub_setup_connection
   stub(IndexTank).setup_connection(anything) do |url|
     Faraday::Connection.new(:url => url) do |builder|
+      builder.use FaradayStack::ResponseJSON
       builder.adapter :test, stubs
-      builder.use Faraday::Response::Yajl
     end
   end
 end


### PR DESCRIPTION
In Faraday 0.6, `register_on_complete` method is gone and middleware order is significant.

For parsing JSON, use "faraday-stack" library which provides the `FaradayStack::ResponseJSON` middleware. Faraday core doesn't provide json parsing anymore.

**This switch breaks tests heavily**. I didn't have time to find out why. Someone has to dive in and fix the test suite.

I would also suggest refactoring things a bit so you don't create that many instances of Faraday. One stack will do.
