### PR TITLE
Specify dependency, indextank will not work with faraday-stack 0.1.3.

### DIFF
--- a/indextank.gemspec
+++ b/indextank.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rake>, [">= 0.8.7"])
       s.add_development_dependency(%q<ruby-debug>, [">= 0"])
       s.add_development_dependency(%q<parka>, [">= 0.3.1"])
-      s.add_runtime_dependency(%q<faraday-stack>, [">= 0"])
+      s.add_runtime_dependency(%q<faraday-stack>, [">= 0.1.5"])
       s.add_runtime_dependency(%q<yajl-ruby>, [">= 0.7.7"])
     else
       s.add_dependency(%q<jeweler>, [">= 1.4.0"])
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rake>, [">= 0.8.7"])
       s.add_dependency(%q<ruby-debug>, [">= 0"])
       s.add_dependency(%q<parka>, [">= 0.3.1"])
-      s.add_dependency(%q<faraday-stack>, [">= 0"])
+      s.add_dependency(%q<faraday-stack>, [">= 0.1.5"])
       s.add_dependency(%q<yajl-ruby>, [">= 0.7.7"])
     end
   else
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rake>, [">= 0.8.7"])
     s.add_dependency(%q<ruby-debug>, [">= 0"])
     s.add_dependency(%q<parka>, [">= 0.3.1"])
-    s.add_dependency(%q<faraday-stack>, [">= 0"])
+    s.add_dependency(%q<faraday-stack>, [">= 0.1.5"])
     s.add_dependency(%q<yajl-ruby>, [">= 0.7.7"])
   end
 end


### PR DESCRIPTION
Indextank does not work with 0.1.3. Due to an issue with faraday-stack, if a user has something like omniauth-facebook installed indextank will install 0.1.3 since there is no dependency requirement.

Signed-off-by: Marc MacLeod marbemac@gmail.com
